### PR TITLE
Update and rename docs/doxygen/Doxyfile to .codedocs

### DIFF
--- a/.codedocs
+++ b/.codedocs
@@ -823,8 +823,9 @@ WARN_LOGFILE           = warnings.txt
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = "xplatform.dox"
-INPUT                 += "../../include/os"
+INPUT                  = "./docs/doxygen/xplatform.dox" \
+                         "./README.md" \
+                         "./include/os"
 
 
 # This tag can be used to specify the character encoding of the source files


### PR DESCRIPTION
Moved Doxygen configuration file into root as '.codedocs' for proper detection by codedocs.xyz